### PR TITLE
Bug fix for manage.js to perform update into Cloudant

### DIFF
--- a/public/js/manage.js
+++ b/public/js/manage.js
@@ -400,7 +400,7 @@ function getJob(id) {
 function updateJob(job) {
   $.ajax({
     type: "POST",
-    url: '/db/jobs/' + job.id,
+    url: '/db/jobs/',
     data: job,
     dataType: 'json',
     success: function(data) {


### PR DESCRIPTION
 url: '/db/jobs/' + job.id will give HTTP Post in which db.js does not have app.post function to handle it.
